### PR TITLE
add are.na types; cleanup search own code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
         "@raycast/api": "^1.82.5",
         "are.na": "github:isabelsa/arena-js",
         "date-fns": "^3.6.0",
-        "node-fetch": "^3.3.2",
-        "rss-parser": "^3.12.0"
+        "node-fetch": "^3.3.2"
       },
       "devDependencies": {
         "@raycast/eslint-config": "^1.0.6",
+        "@types/are.na": "^0.1.4",
         "@types/node": "20.8.10",
         "@types/react": "18.2.27",
         "eslint": "^8.51.0",
@@ -283,6 +283,13 @@
       "version": "1.10.4",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.10.4.tgz",
       "integrity": "sha512-WJgX9nzTqknM393q1QJDJmoW28kUfEnybeTfVNcNAPnIx210RXm2DiXiHzfNPJNIUUb1tJnz/l4QGtJ30PgWmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/are.na": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@types/are.na/-/are.na-0.1.4.tgz",
+      "integrity": "sha512-FBvIOY7Y/rYYWYZhHH+sVXNYr37luAfMXhe/OsJYA4TPCfj2MSVIOsVyKmWK9bgVIZl9Mbok0IAGOp8UwGgkFA==",
       "dev": true,
       "license": "MIT"
     },
@@ -982,15 +989,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -2233,16 +2231,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rss-parser": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.13.0.tgz",
-      "integrity": "sha512-7jWUBV5yGN3rqMMj7CZufl/291QAhvrrGpDNE4k/02ZchL0npisiYYqULF71jCEKoIiHvK/Q2e6IkDwPziT7+w==",
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^2.0.3",
-        "xml2js": "^0.5.0"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -2266,12 +2254,6 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
-    },
-    "node_modules/sax": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
-      "license": "ISC"
     },
     "node_modules/semver": {
       "version": "7.6.3",
@@ -2546,28 +2528,6 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/xml2js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
-      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
-      "license": "MIT",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@raycast/eslint-config": "^1.0.6",
+    "@types/are.na": "^0.1.4",
     "@types/node": "20.8.10",
     "@types/react": "18.2.27",
     "eslint": "^8.51.0",

--- a/src/arena.ts
+++ b/src/arena.ts
@@ -1,0 +1,16 @@
+import { getPreferenceValues } from "@raycast/api";
+import Arena from "are.na";
+
+const preferences = getPreferenceValues();
+const arena = new Arena({ accessToken: preferences.token });
+
+const getChannelsForUser = (user: Arena.User): Promise<Arena.Channel[]> => arena.user(user.slug).channels();
+
+// @ts-expect-error: The 'me' method exists in our forked version of the Arena library
+// We've extended the Arena type to include the 'me' method for authenticated user operations
+const getAuthenticatedUser = (): Promise<Arena.User> => arena.me().get();
+
+export const getChannelsForAuthenticatedUser = async (): Promise<Arena.Channel[]> => {
+  const user = await getAuthenticatedUser();
+  return getChannelsForUser(user);
+};

--- a/src/data.tsx
+++ b/src/data.tsx
@@ -1,24 +1,4 @@
-import { Block, State } from "./types";
-
-
-export function getOwnChannels(arena: any, state: State, setState: any, setIsLoading: any) {
-  setIsLoading(true);
-
-  arena.me().get().then((user: any) => {
-    arena
-    .user(user.slug)
-    .channels()
-    .then((channels: any) => {
-      channels.map((ch: any) => {
-      setState((prev: any) => ({ ...prev, items: [...channels] }));
-    });
-
-  })
-  .then(() => setIsLoading(false))
-  .catch((err: any) => console.log(err));
-  });
-}
-
+import { Block } from "./types";
 
 export function getChannelContents(arena: any, channel: any, set: any, setIsLoading: any) {
   arena
@@ -35,8 +15,7 @@ export function getChannelContents(arena: any, channel: any, set: any, setIsLoad
           createdAt: x.created_at,
           commentCount: x.commentCount,
           description: x.description,
-          source: x.source?.url  
-
+          source: x.source?.url,
         };
 
         set((prev: any) => [...prev, block]);

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -21,25 +21,3 @@ export type Block = {
 export type Slug = {
   id: string;
 };
-
-export type Channel = {
-  id: string;
-  index: string;
-  title: string;
-  user: {
-    slug: string;
-  }
-  length: number;
-  updated_at: string;
-  follower_count: string;
-  slug: string;
-  open: string;
-  status: string;
-};
-
-export type State = {
-  searchText: string;
-  items: Channel[];
-};
-
-

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -23,7 +23,7 @@ export function generateThumbnail(text: string): Image.ImageLike {
   };
 }
 
-export function generateIcon(text: string, open: string, status: string): Image.ImageLike {
+export function generateIcon(text: string, open: boolean, status: string): Image.ImageLike {
   const truncate = Array.from(text)[0];
   const letter = truncate.toString().toUpperCase();
 


### PR DESCRIPTION
- import `are.na` types (would be nice to fork it to add `me` method)
- create `arena.ts` utils
- fix search through own channels 
- add error toast when fetch fails

Plan is to remove `types.tsx` and `data.tsx`
